### PR TITLE
Don't close the MessageInputStream after signalling the arrival of a response, it will get closed after the response has been handled

### DIFF
--- a/src/main/java/org/wildfly/naming/client/remote/RemoteClientTransport.java
+++ b/src/main/java/org/wildfly/naming/client/remote/RemoteClientTransport.java
@@ -164,18 +164,19 @@ final class RemoteClientTransport {
             }
 
             public void handleMessage(final Channel channel, final MessageInputStream message) {
-                try (MessageInputStream mis = message) {
-                    final int messageId = mis.readUnsignedByte();
-                    final int id = readId(mis);
-                    final int result = mis.readUnsignedByte();
+                try {
+                    final int messageId = message.readUnsignedByte();
+                    final int id = readId(message);
+                    final int result = message.readUnsignedByte();
                     if (result == Protocol.SUCCESS || result == Protocol.FAILURE) {
-                        tracker.signalResponse(id, messageId, mis, true);
+                        tracker.signalResponse(id, messageId, message, true);
                     } else {
                         throw Messages.log.outcomeNotUnderstood();
                     }
                     channel.receiveMessage(this);
                 } catch (IOException e) {
                     safeClose(channel);
+                    safeClose(message);
                 }
             }
         });


### PR DESCRIPTION
I was running into a problem where an ``EOFException`` would sometimes occur in [RemoteClientTransport#lookup](https://github.com/wildfly/wildfly-naming-client/blob/master/src/main/java/org/wildfly/naming/client/remote/RemoteClientTransport.java#L214). It seems that the underlying issue was that the ``MessageInputStream`` was being closed after signalling the arrival of a response, before ``RemoteClientTransport#lookup`` had a chance to actually handle the response. This PR fixes this by no longer closing the ``MessageInputStream`` after signalling the arrival of a response (it gets closed in ``RemoteClientTransport#lookup`` after the response has been handled).