### PR TITLE
[WFNC-18] Add the ability to support certain EJB properties specified in the InitialContext environment

### DIFF
--- a/src/main/java/org/wildfly/naming/client/util/EnvironmentUtils.java
+++ b/src/main/java/org/wildfly/naming/client/util/EnvironmentUtils.java
@@ -48,6 +48,18 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  */
 public final class EnvironmentUtils {
 
+    // Constants related to EJB remote connections in environment properties
+    public static final String EJB_REMOTE_CONNECTIONS = "remote.connections";
+    public static final String EJB_REMOTE_CONNECTION_PREFIX = "remote.connection.";
+    public static final String EJB_REMOTE_CONNECTION_PROVIDER_PREFIX = "remote.connectionprovider.create.options.";
+    public static final String CONNECT_OPTIONS = "connect.options.";
+    public static final String EJB_HOST_KEY = "host";
+    public static final String EJB_PORT_KEY = "port";
+    public static final String EJB_CALLBACK_HANDLER_CLASS_KEY = "callback.handler.class";
+    public static final String EJB_USERNAME_KEY = "username";
+    public static final String EJB_PASSWORD_KEY = "password";
+    public static final String EJB_PASSWORD_BASE64_KEY = "password.base64";
+
     private EnvironmentUtils() {
     }
 


### PR DESCRIPTION
For example, suppose an InitialContext is created with the following environment properties:

```
Properties props = new Properties();
props.put("remote.connections", "main");
props.put("remote.connection.main.host", "127.0.0.1");
props.put("remote.connection.main.port", "8080");
props.put("remote.connection.main.callback.handler.class", "org.jboss.as.test.integration.ejb.mapbased.CustomCallbackHandler");
props.put("remote.connection.main.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS", "false");
props.put("remote.connection.main.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "true");
props.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
InitialContext ctx = new InitialContext(props);
```

Currently, we are ignoring all EJB properties that are passed to the InitialContext programmatically as shown above. The changes in this PR would allow us to interpret the above EJB properties as the following equivalent naming properties:

```
java.naming.provider.url = "remote+http://127.0.0.1:8080"
jboss.naming.client.security.callback.handler.class = "org.jboss.as.test.integration.ejb.mapbased.CustomCallbackHandler"
jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS = "false"
jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT = "true"
```
