### PR TITLE
WFNC-48 - Add support for automatic retry when multiple provider URIs are specified.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <version.org.jboss.xnio>3.5.1.Final</version.org.jboss.xnio>
+        <version.org.jboss.threads>2.2.1.Final</version.org.jboss.threads>
     </properties>
 
     <groupId>org.wildfly</groupId>
@@ -123,6 +125,22 @@
             <artifactId>jboss-remoting</artifactId>
             <version>5.0.0.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>${version.org.jboss.xnio}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+            <version>${version.org.jboss.xnio}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
+            <version>${version.org.jboss.threads}</version>
+        </dependency>
+
 
         <!-- JUnit -->
         <dependency>

--- a/src/main/java/org/wildfly/naming/client/ExhaustedDestinationsException.java
+++ b/src/main/java/org/wildfly/naming/client/ExhaustedDestinationsException.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.naming.client;
+
+import javax.naming.CommunicationException;
+
+/**
+ * Indicates that no more destinations are available to complete a naming
+ * operation. Since this failure may represent multiple failures across mutliple
+ * destinations, {@link #getSuppressed()} should be examined for a list of
+ * underlying failures.
+ *
+ * @author Jason T. Greene
+ */
+public class ExhaustedDestinationsException extends CommunicationException {
+
+    public ExhaustedDestinationsException() {
+    }
+
+    public ExhaustedDestinationsException(String explanation) {
+        super(explanation);
+    }
+}

--- a/src/main/java/org/wildfly/naming/client/NamingOperation.java
+++ b/src/main/java/org/wildfly/naming/client/NamingOperation.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.naming.client;
+
+import javax.naming.Name;
+import javax.naming.NamingException;
+
+/**
+ * A functional type for naming operations.
+ *
+ * @author Jason T. Greene
+ */
+@FunctionalInterface
+public interface NamingOperation<T, R> {
+    R apply(RetryContext contextOrNull, Name name, T param) throws NamingException;
+}

--- a/src/main/java/org/wildfly/naming/client/RetryContext.java
+++ b/src/main/java/org/wildfly/naming/client/RetryContext.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.naming.client;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A context with an invocation life-span that maintains state useful to
+ * retrying naming operations.
+ *
+ * @author Jason T. Greene
+ */
+@SuppressWarnings("WeakerAccess")
+public final class RetryContext {
+
+    static int MAX_RECORDED_FAILURES = 10;
+
+    private URI destination;
+    private Set<URI> transientFailed = Collections.emptySet();
+    private List<Throwable> failures = Collections.emptyList();
+    private boolean explicitFailure = false;
+
+    /**
+     * Sets the current destination being attempted by the invocation.
+     *
+     * @param destination the current destination
+     */
+    public void setCurrentDestination(URI destination) {
+        this.destination = destination;
+    }
+
+    /**
+     * Gets the current destination being attempted by the invocation.
+     *
+     * @return the current destination
+     */
+    public URI currentDestination() {
+        return destination;
+    }
+
+    /**
+     * Indicates whether the specified destination has been registered as
+     * failing as part of this invocation. Note that this will only return true
+     * for destinations that have transiently failed. If there is a blacklist
+     * entry for a destination, then it is not recorded as a transient failure.
+     *
+     * @param destination the destination to check
+     * @return true if a transient failure is registered
+     */
+    public boolean hasTransientlyFailed(URI destination) {
+        return transientFailed.contains(destination);
+    }
+
+    /**
+     * Registers a destination as having transiently failed. Destinations
+     * that have transiently failed should not be retried in the
+     * corresponding invocation of this context. However, future invocations
+     * should retry, unlike a black-listed destination, which instead utilizes
+     * time-based back-off.
+     *
+     * @param destination the destination to record a transient failure
+     */
+    public void addTransientFail(URI destination) {
+        if (transientFailed.size() == 0) {
+            transientFailed = new HashSet<>(1);
+        }
+        transientFailed.add(destination);
+    }
+
+    /**
+     * Return the current number of transient failures that have been registered
+     * against this context.
+     *
+     * @return the number of transient failures registered
+     */
+    public int transientFailCount() {
+        return transientFailed.size();
+    }
+
+    /**
+     * Gets a list of exceptions for failures that have occurred while retrying
+     * this invocation. Note that this list may include both black-listed and
+     * transient failures, and is not necessarily exhaustive. This list is
+     * purely intended for informational error-reporting. Callers should not
+     * make assumptions based on the content of it.
+     *
+     * @return a list of throwables thrown while attempting contact with a
+     *         destination
+     */
+    public List<Throwable> getFailures() {
+        return failures;
+    }
+
+    /**
+     * Indicates to a naming provider that this exception should be thrown, as
+     * opposed to a "no more destinations" summary exception, if no other
+     * destinations are successful during the invocation.
+     *
+     * @param failure the Throwable that should be thrown if no other
+     *                destinations succeed.
+     */
+    public void addExplicitFailure(Throwable failure) {
+        explicitFailure = true;
+        failures = Collections.singletonList(failure);
+    }
+
+    /**
+     * Returns true if an explicit failure has been registered. This occurs as
+     * the result of a call to {@link #addExplicitFailure(Throwable)}.
+     *
+     * @return true if an explicit failure has been registered.
+     */
+    public boolean hasExplicitFailure() {
+        return explicitFailure;
+    }
+
+
+    /**
+     * Register an exception that was observed while attempting to execute an
+     * operation against a destination.
+     *
+     * @param failure the throwable thrown during a destination attempt
+     */
+    public void addFailure(Throwable failure) {
+        if (explicitFailure || failures.size() >= MAX_RECORDED_FAILURES) {
+            return;
+        }
+
+        if (failures.size() == 0) {
+            failures = new ArrayList<>(1);
+        }
+
+        // Store only one exception per "type" of failure
+        failures.add(failure);
+    }
+}

--- a/src/main/java/org/wildfly/naming/client/_private/Messages.java
+++ b/src/main/java/org/wildfly/naming/client/_private/Messages.java
@@ -46,6 +46,7 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Once;
 import org.jboss.logging.annotations.Property;
+import org.wildfly.naming.client.ExhaustedDestinationsException;
 import org.wildfly.naming.client.RenameAcrossNamingProvidersException;
 import org.wildfly.security.auth.AuthenticationException;
 
@@ -238,4 +239,10 @@ public interface Messages extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 54, value = "Ignoring duplicate destination URI \"%s\"")
     void ignoringDuplicateDestination(URI uri);
+
+    @Message(id = 55, value = "No more destinations are available to attempt the operation (%d blacklisted, %d transiently failed). See suppressed exceptions for details")
+    ExhaustedDestinationsException noMoreDestinations(int blacklisted, int transientlyFailed);
+
+    @Message(id = 56, value = "No more destinations are available to attempt the operation.")
+    ExhaustedDestinationsException noMoreDestinations();
 }

--- a/src/main/java/org/wildfly/naming/client/remote/RemoteContext.java
+++ b/src/main/java/org/wildfly/naming/client/remote/RemoteContext.java
@@ -19,7 +19,10 @@
 package org.wildfly.naming.client.remote;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
 import java.util.Hashtable;
+import java.util.IdentityHashMap;
 
 import javax.naming.Binding;
 import javax.naming.CommunicationException;
@@ -28,6 +31,7 @@ import javax.naming.Context;
 import javax.naming.InvalidNameException;
 import javax.naming.Name;
 import javax.naming.NameClassPair;
+import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 
 import org.jboss.remoting3.Connection;
@@ -35,6 +39,10 @@ import org.jboss.remoting3.ConnectionPeerIdentity;
 import org.jboss.remoting3.Endpoint;
 import org.wildfly.naming.client.AbstractFederatingContext;
 import org.wildfly.naming.client.CloseableNamingEnumeration;
+import org.wildfly.naming.client.ExhaustedDestinationsException;
+import org.wildfly.naming.client.NamingOperation;
+import org.wildfly.naming.client.ProviderEnvironment;
+import org.wildfly.naming.client.RetryContext;
 import org.wildfly.naming.client._private.Messages;
 import org.wildfly.naming.client.store.RelativeFederatingContext;
 import org.wildfly.naming.client.util.FastHashtable;
@@ -49,6 +57,7 @@ import org.xnio.OptionMap;
  */
 final class RemoteContext extends AbstractFederatingContext {
 
+    private static final int MAX_NOT_FOUND_RETRY = 8;
     private final RemoteNamingProvider provider;
     private final String scheme;
 
@@ -81,6 +90,77 @@ final class RemoteContext extends AbstractFederatingContext {
         }
     }
 
+    private boolean canRetry(ProviderEnvironment environment) {
+        return environment.getProviderUris().size() > 1;
+    }
+
+    private  <T, R> R performWithRetry(NamingOperation<T, R> function, ProviderEnvironment environment, RetryContext context, Name name, T param) throws NamingException {
+        // Directly pass-through single provider executions
+        if (context == null) {
+            return function.apply(null, name, param);
+        }
+
+        for (int notFound = 0;;) {
+            try {
+                R result = function.apply(context, name, param);
+                environment.dropFromBlacklist(context.currentDestination());
+                return result;
+            } catch (NameNotFoundException e) {
+                if (notFound++ > MAX_NOT_FOUND_RETRY) {
+                    Messages.log.tracef("Maximum name not found attempts exceeded,");
+                    throw e;
+                }
+                URI location = context.currentDestination();
+                Messages.log.tracef("Provider (%s) did not have name \"%s\" (or a portion), retrying other nodes", location, name);
+
+                // Always throw NameNotFoundException, unless we find it on another host
+                context.addExplicitFailure(e);
+                context.addTransientFail(location);
+            } catch (ExhaustedDestinationsException e) {
+                throw e;
+            } catch (CommunicationException t) {
+                URI location = context.currentDestination();
+                Messages.log.tracef(t, "Communication error while contacting %s", location);
+                updateBlackList(environment, context, t);
+                context.addFailure(injectDestination(t, location));
+            } catch (NamingException e) {
+                // All other naming exceptions are legit errors
+                environment.dropFromBlacklist(context.currentDestination());
+                throw e;
+            } catch (Throwable t) {
+                // Don't black-list generic throwables since it may indicate a client bug
+                URI location = context.currentDestination();
+                Messages.log.tracef(t, "Unexpected throwable while contacting %s", location);
+                context.addTransientFail(location);
+                context.addFailure(injectDestination(t, location));
+            }
+        }
+    }
+
+    private static Throwable injectDestination(Throwable t, URI destination) {
+        StackTraceElement[] stackTrace = new StackTraceElement[5];
+        System.arraycopy(t.getStackTrace(), 0, stackTrace, 1, 4);
+        stackTrace[0] = new StackTraceElement("", "..use of destination...", destination.toString(), -1);
+        t.setStackTrace(stackTrace);
+
+        IdentityHashMap<Throwable, Throwable> encountered = new IdentityHashMap<>(3);
+        encountered.put(t, t);
+        Throwable cause = t.getCause();
+        while (cause != null && encountered.get(cause) == null) {
+            encountered.put(cause, cause);
+            cause.setStackTrace(Arrays.copyOfRange(cause.getStackTrace(), 0, 5));
+            cause = cause.getCause();
+        }
+
+        return t;
+    }
+
+    private void updateBlackList(ProviderEnvironment environment, RetryContext context, Throwable t) {
+        URI location = context.currentDestination();
+        Messages.log.tracef(t, "Provider (%s) failed, blacklisting and retrying", location);
+        environment.updateBlacklist(location);
+    }
+
     Name getRealName(Name name) throws InvalidNameException {
         // this could go away after WFNC-20
         if (scheme == null) {
@@ -101,10 +181,14 @@ final class RemoteContext extends AbstractFederatingContext {
         if (realName.isEmpty()) {
             return new RemoteContext(provider, scheme, getEnvironment());
         }
-        return provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        return performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             return getRemoteTransport(peerIdentity).lookup(this, name_, peerIdentity, false);
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     protected Object lookupLinkNative(final Name name) throws NamingException {
@@ -112,82 +196,109 @@ final class RemoteContext extends AbstractFederatingContext {
         if (realName.isEmpty()) {
             return new RemoteContext(provider, scheme, getEnvironment());
         }
-        return provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        return performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             return getRemoteTransport(peerIdentity).lookup(this, name_, peerIdentity, true);
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     protected void bindNative(final Name name, final Object obj) throws NamingException {
         Name realName = getRealName(name);
-        provider.performExceptionAction((name_, obj_) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        performWithRetry((context_, name_, obj_) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             getRemoteTransport(peerIdentity).bind(name_, obj_, peerIdentity, false);
             return null;
-        }, realName, obj);
+        }, environment, context, realName, obj);
     }
 
     protected void rebindNative(final Name name, final Object obj) throws NamingException {
         Name realName = getRealName(name);
-        provider.performExceptionAction((name_, obj_) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        performWithRetry((context_, name_, obj_) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             getRemoteTransport(peerIdentity).bind(name_, obj_, peerIdentity, true);
             return null;
-        }, realName, obj);
+        }, environment, context, realName, obj);
     }
 
     protected void unbindNative(final Name name) throws NamingException {
         Name realName = getRealName(name);
-        provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             getRemoteTransport(peerIdentity).unbind(name_, peerIdentity);
             return null;
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     protected void renameNative(final Name oldName, final Name newName) throws NamingException {
         Name realOldName = getRealName(oldName);
         Name realNewName = getRealName(newName);
-        provider.performExceptionAction((oldName_, newName_) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        performWithRetry((context_, oldName_, newName_) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             getRemoteTransport(peerIdentity).rename(oldName_, newName_, peerIdentity);
             return null;
-        }, realOldName, realNewName);
+        }, environment, context, realOldName, realNewName);
     }
 
     protected CloseableNamingEnumeration<NameClassPair> listNative(final Name name) throws NamingException {
         Name realName = getRealName(name);
-        return provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        return performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             return getRemoteTransport(peerIdentity).list(name_, peerIdentity);
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     protected CloseableNamingEnumeration<Binding> listBindingsNative(final Name name) throws NamingException {
         Name realName = getRealName(name);
-        return provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        return performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             return getRemoteTransport(peerIdentity).listBindings(name_, this, peerIdentity);
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     protected void destroySubcontextNative(final Name name) throws NamingException {
         Name realName = getRealName(name);
-        provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             getRemoteTransport(peerIdentity).destroySubcontext(name_, peerIdentity);
             return null;
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     protected Context createSubcontextNative(final Name name) throws NamingException {
         Name realName = getRealName(name);
-        return provider.performExceptionAction((name_, ignored) -> {
-            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNaming();
+        ProviderEnvironment environment = provider.getProviderEnvironment();
+        final RetryContext context = canRetry(environment) ? new RetryContext() : null;
+
+        return performWithRetry((context_, name_, ignored) -> {
+            final ConnectionPeerIdentity peerIdentity = provider.getPeerIdentityForNamingUsingRetry(context_);
             final CompositeName compositeName = NamingUtils.toCompositeName(name_);
             getRemoteTransport(peerIdentity).createSubcontext(compositeName, peerIdentity);
             return new RelativeFederatingContext(getEnvironment(), this, compositeName);
-        }, realName, null);
+        }, environment, context, realName, null);
     }
 
     public void close() {

--- a/src/main/java/org/wildfly/naming/client/remote/RemoteNamingProvider.java
+++ b/src/main/java/org/wildfly/naming/client/remote/RemoteNamingProvider.java
@@ -34,6 +34,7 @@ import org.jboss.remoting3.Endpoint;
 import org.wildfly.common.Assert;
 import org.wildfly.naming.client.NamingProvider;
 import org.wildfly.naming.client.ProviderEnvironment;
+import org.wildfly.naming.client.RetryContext;
 import org.wildfly.naming.client._private.Messages;
 import org.wildfly.naming.client.util.FastHashtable;
 import org.wildfly.security.auth.AuthenticationException;
@@ -83,6 +84,11 @@ public final class RemoteNamingProvider implements NamingProvider {
      */
     public ConnectionPeerIdentity getPeerIdentityForNaming() throws NamingException {
         return (ConnectionPeerIdentity) NamingProvider.super.getPeerIdentityForNaming();
+    }
+
+
+    public ConnectionPeerIdentity getPeerIdentityForNamingUsingRetry(RetryContext context) throws NamingException {
+        return (ConnectionPeerIdentity) NamingProvider.super.getPeerIdentityForNamingUsingRetry(context);
     }
 
     /**

--- a/src/test/java/org/wildfly/naming/client/BlackListTestCase.java
+++ b/src/test/java/org/wildfly/naming/client/BlackListTestCase.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.naming.client;
+
+import static org.wildfly.naming.client.ProviderEnvironment.TIME_MASK;
+
+import java.net.URI;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Simple test to verify black-list backoff
+ *
+ * @author Jason T. Greene
+ */
+public class BlackListTestCase {
+
+    @Test
+    public void testBackOff() throws Exception {
+        ProviderEnvironment.Builder builder = new ProviderEnvironment.Builder();
+        ProviderEnvironment env = builder.build();
+        URI foo = new URI("remote://foo");
+
+        Assert.assertFalse(env.getBlackList().containsKey(foo));
+
+
+        for (int i = 0; i < 14; i++) {
+            long currentTime = System.currentTimeMillis();
+            env.updateBlacklist(foo);
+
+            Long entry = env.getBlackList().get(foo);
+            Assert.assertNotNull(entry);
+
+            int difference = (int) ((entry & TIME_MASK) - currentTime);
+            int expectedLow = (1 << i) * 65536;
+            int expectedHigh = ((1 << i) + 1) * 65536;
+
+            String expected = String.format("Expected difference of iteration %d to be between %d and %d, but was %d [*] delta = %d | %d (mul %d) - [*] %s", i, expectedLow, expectedHigh, difference, difference - expectedLow, difference - expectedHigh, entry & ~TIME_MASK, formatDuration(difference));
+            Assert.assertTrue(expected, difference >= expectedLow && difference <= expectedHigh);
+            Assert.assertEquals(1 << (i + 1), entry & ~TIME_MASK);
+        }
+
+        // Verify backoff progression stops at 6 days
+        for (int i = 15; i < 30; i++) {
+            long currentTime = System.currentTimeMillis();
+            env.updateBlacklist(foo);
+
+            Long entry = env.getBlackList().get(foo);
+            Assert.assertNotNull(entry);
+
+            int difference = (int) ((entry & TIME_MASK) - currentTime);
+            int expectedLow = (1 << 13) * 65536;
+            int expectedHigh = ((1 << 13) + 1) * 65536;
+
+            String expected = String.format("Expected difference of iteration %d to be between %d and %d, but was %d [*] delta = %d | %d (mul %d) - [*] %s", i, expectedLow, expectedHigh, difference, difference - expectedLow, difference - expectedHigh, entry & ~TIME_MASK, formatDuration(difference));
+            Assert.assertTrue(expected, difference >= expectedLow && difference <= expectedHigh);
+            Assert.assertEquals(1 << (13 + 1), entry & ~TIME_MASK);
+        }
+    }
+
+    private static String formatDuration(long duration) {
+        int days = (int)(duration / 86400_000L);
+        duration -= days * 86400_000L;
+        int hours = (int) (duration / 3600_000L);
+        duration -= hours * 3600_000L;
+        int mins = (int) (duration / 60_000);
+        duration -= mins * 60_000;
+        int secs = (int) (duration / 1000);
+        duration -= secs * 1000;
+        int millis = (int) duration;
+
+        return ((days > 0) ? String.format("%d days,", days) : "") +
+                ((hours > 0) ? String.format("%d hours,", hours) : "") +
+                ((mins > 0) ? String.format("%d mins,", mins) : "") +
+                ((secs > 0) ? String.format("%d secs,", secs) : "") +
+                ((millis > 0) ? String.format("%d mils", millis) : "");
+    }
+}

--- a/src/test/java/org/wildfly/naming/client/remote/FlatMockContext.java
+++ b/src/test/java/org/wildfly/naming/client/remote/FlatMockContext.java
@@ -1,0 +1,234 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.naming.client.remote;
+
+import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.InvalidNameException;
+import javax.naming.Name;
+import javax.naming.NameAlreadyBoundException;
+import javax.naming.NameClassPair;
+import javax.naming.NameNotFoundException;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+
+import org.wildfly.naming.client.SimpleName;
+import org.wildfly.naming.client._private.Messages;
+
+/**
+ * Partially implemented ultra-simple flat JNDI context
+ *
+ * @author Jason T. Greene
+ */
+class FlatMockContext implements Context {
+
+    private ConcurrentMap<String, Object> entries = new ConcurrentHashMap<>();
+    private final AtomicInteger notFoundCounter = new AtomicInteger(0);
+
+    @Override
+    public Object lookup(Name name) throws NamingException {
+        if (name.size() <= 0) {
+            return this;
+        } else if (name.size() == 1) {
+            String key = name.get(0);
+            if ("$$$notFound$$$".equals(key)) {
+                return notFoundCounter.get();
+            }
+            Object result = entries.get(key);
+            if (result == null) {
+                notFoundCounter.incrementAndGet();
+                throw new NameNotFoundException();
+            }
+            return result;
+        } else {
+            throw Messages.log.notSupported();
+        }
+    }
+
+    @Override
+    public Object lookup(String name) throws NamingException {
+        return lookup(new SimpleName(name));
+    }
+
+    @Override
+    public void bind(Name name, Object obj) throws NamingException {
+        bindInternal(name, obj, false);
+    }
+
+    private void bindInternal(Name name, Object obj, boolean overwrite) throws NamingException {
+        if (name.size() <= 0) {
+            throw new InvalidNameException();
+        } else if (name.size() == 1) {
+            if (overwrite) {
+                entries.put(name.get(0), obj);
+                return;
+            }
+            Object result = entries.putIfAbsent(name.get(0), obj);
+            if (result != null) {
+                throw new NameAlreadyBoundException();
+            }
+        } else {
+            throw Messages.log.notSupported();
+        }
+    }
+
+    @Override
+    public void bind(String name, Object obj) throws NamingException {
+        bind(new SimpleName(name), obj);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj) throws NamingException {
+        bindInternal(name, obj, true);
+    }
+
+    @Override
+    public void rebind(String name, Object obj) throws NamingException {
+        rebind(new SimpleName(name), obj);
+
+    }
+
+    @Override
+    public void unbind(Name name) throws NamingException {
+        if (name.size() <= 0) {
+            throw new InvalidNameException();
+        } else if (name.size() == 1) {
+            entries.remove(name.get(0));
+        } else {
+            throw Messages.log.notSupported();
+        }
+
+    }
+
+    @Override
+    public void unbind(String name) throws NamingException {
+        unbind(new SimpleName(name));
+    }
+
+    @Override
+    public void rename(Name oldName, Name newName) throws NamingException {
+        bind(newName, lookup(oldName));
+        unbind(oldName);
+    }
+
+    @Override
+    public void rename(String oldName, String newName) throws NamingException {
+        rename(new SimpleName(oldName), new SimpleName(newName));
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public void destroySubcontext(Name name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public void destroySubcontext(String name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public Context createSubcontext(Name name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public Context createSubcontext(String name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public Object lookupLink(Name name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public Object lookupLink(String name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public NameParser getNameParser(Name name) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public NameParser getNameParser(String name) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public Name composeName(Name name, Name prefix) throws NamingException {
+        return null;
+    }
+
+    @Override
+    public String composeName(String name, String prefix) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public Object removeFromEnvironment(String propName) throws NamingException {
+        throw Messages.log.notSupported();
+    }
+
+    @Override
+    public Hashtable<?, ?> getEnvironment() throws NamingException {
+       throw Messages.log.notSupported();
+    }
+
+    @Override
+    public void close() throws NamingException {
+
+    }
+
+    @Override
+    public String getNameInNamespace() throws NamingException {
+        throw Messages.log.notSupported();
+    }
+}

--- a/src/test/java/org/wildfly/naming/client/remote/RemoteContextTestCase.java
+++ b/src/test/java/org/wildfly/naming/client/remote/RemoteContextTestCase.java
@@ -20,19 +20,275 @@ package org.wildfly.naming.client.remote;
 
 import static junit.framework.Assert.assertEquals;
 
+import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.Hashtable;
 
 import javax.naming.Name;
+import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.wildfly.naming.client.ExhaustedDestinationsException;
+import org.wildfly.naming.client.ProviderEnvironment;
+import org.wildfly.naming.client.WildFlyInitialContextFactory;
 import org.wildfly.naming.client.WildFlyRootContext;
 import org.wildfly.naming.client.util.FastHashtable;
 
 /**
+ * Tests various remote operations using RemoteContext
+ *
+ * @author Jason T. Greene
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
 public class RemoteContextTestCase {
+    public TestServer server;
+
+    @Before
+    public void setup() throws Exception {
+        server = new TestServer("test", "localhost", 9898);
+        server.start();
+    }
+
+    @After
+    public void tearDown() {
+        server.stop();
+    }
+
+    private void bindOnServer(String server, String key, Object obj) throws Exception {
+        FastHashtable<String, Object> props = new FastHashtable<>();
+        // Include all servers, so that retries are also tested
+        props.put("java.naming.provider.url", server);
+        props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+        WildFlyRootContext context = new WildFlyRootContext(props);
+        context.bind(key, obj);
+    }
+
+    private Object lookupOnServer(String server, String key) throws Exception {
+        FastHashtable<String, Object> props = new FastHashtable<>();
+        // Include all servers, so that retries are also tested
+        props.put("java.naming.provider.url", server);
+        props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+        WildFlyRootContext context = new WildFlyRootContext(props);
+        return context.lookup(key);
+    }
+
+    private int getServerNotFoundCount(String SERVER1) throws Exception {
+        return toInt(lookupOnServer(SERVER1, "$$$notFound$$$"));
+    }
+
+    private int toInt(Object o) {
+        return Integer.class.cast(o);
+    }
+
+    @Test
+    public void testOneWithNameAndOneWithout() throws Exception {
+        final String SERVER1 = "remote://localhost:9898";
+        final String SERVER2 = "remote://localhost:9896";
+
+        TestServer server2 = new TestServer("test2", "localhost", 9896);
+        server2.start();
+        try {
+            FastHashtable<String, Object> props = new FastHashtable<>();
+
+            // Include all servers, so that retries are also tested
+            props.put("java.naming.provider.url", SERVER1 + "," + SERVER2);
+            props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+            WildFlyRootContext context = new WildFlyRootContext(props);
+
+            bindOnServer(SERVER2, "hello", "there");
+            for (int i = 0; i < 20; i++) {
+                Assert.assertEquals("there", context.lookup("hello"));
+
+            }
+
+            bindOnServer(SERVER1, "quick", "fox");
+            int total = 0;
+            for (int i = 0; i < 10; i++) {
+                int start1 = getServerNotFoundCount(SERVER1);
+                int start2 = getServerNotFoundCount(SERVER2);
+                Assert.assertEquals("there", context.lookup("hello"));
+                Assert.assertEquals("fox", context.lookup("quick"));
+                int count1 = getServerNotFoundCount(SERVER1) - start1;
+                int count2 = getServerNotFoundCount(SERVER2) - start2;
+
+                Assert.assertTrue(count1 < 2 && count1 >= 0);
+                Assert.assertTrue(count2 < 2 && count2 >= 0);
+
+                total += count1 + count2;
+            }
+
+            // Must be less than total invocations
+            Assert.assertTrue(total < 20);
+
+            Field providerEnvironment = context.getClass().getDeclaredField("providerEnvironment");
+            providerEnvironment.setAccessible(true);
+            ProviderEnvironment env = (ProviderEnvironment) providerEnvironment.get(context);
+            Assert.assertEquals(0, env.getBlackList().size());
+
+        } finally {
+            server2.stop();
+        }
+    }
+
+
+    @Test
+    public void testOneOfThreeUp() throws Exception {
+        FastHashtable<String, Object> props = new FastHashtable<>();
+
+        // Include all servers, so that retries are also tested
+        props.put("java.naming.provider.url", "remote://localhost:9897,remote://localhost:9896,remote://localhost:9898");
+        props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+        WildFlyRootContext context = new WildFlyRootContext(props);
+
+        for (int i = 0; i < 10; i++) {
+            context.bind("hello", "there");
+            Assert.assertEquals("there", context.lookup("hello"));
+        }
+
+        Field providerEnvironment = context.getClass().getDeclaredField("providerEnvironment");
+        providerEnvironment.setAccessible(true);
+        ProviderEnvironment env = (ProviderEnvironment) providerEnvironment.get(context);
+
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9897")));
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9896")));
+        Assert.assertEquals(2, env.getBlackList().size());
+    }
+
+    @Test
+    public void testNotFoundPreference() throws Exception {
+        FastHashtable<String, Object> props = new FastHashtable<>();
+
+        // Include all servers, so that retries are also tested
+        props.put("java.naming.provider.url", "remote://localhost:9897,remote://localhost:9896,remote://localhost:9898");
+        props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+        WildFlyRootContext context = new WildFlyRootContext(props);
+
+        for (int i = 0; i < 10; i++) {
+            NameNotFoundException e = null;
+            try {
+                context.lookup("hello");
+            } catch (NameNotFoundException o) {
+                e = o;
+            }
+
+            Assert.assertNotNull(e);
+        }
+
+        Field providerEnvironment = context.getClass().getDeclaredField("providerEnvironment");
+        providerEnvironment.setAccessible(true);
+        ProviderEnvironment env = (ProviderEnvironment) providerEnvironment.get(context);
+
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9897")));
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9896")));
+        Assert.assertEquals(2, env.getBlackList().size());
+
+        for (int i = 0; i < 10; i++) {
+            NameNotFoundException e = null;
+            try {
+                // Disable black-list to allow for random node distribution
+                env.getBlackList().clear();
+                context.lookup("hello");
+            } catch (NameNotFoundException o) {
+                e = o;
+            }
+
+            Assert.assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void testNoneUp() throws Exception {
+        FastHashtable<String, Object> props = new FastHashtable<>();
+
+        // Include all servers, so that retries are also tested
+        props.put("java.naming.provider.url", "remote://localhost:9897,remote://localhost:9896,remote://localhost:9899");
+        props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+        WildFlyRootContext context = new WildFlyRootContext(props);
+
+        ExhaustedDestinationsException t= null;
+        try {
+            for (int i = 0; i < 10; i++) {
+                context.bind("hello", "there");
+            }
+        } catch (ExhaustedDestinationsException o) {
+            t = o;
+        }
+        Assert.assertNotNull(t);
+
+        Field providerEnvironment = context.getClass().getDeclaredField("providerEnvironment");
+        providerEnvironment.setAccessible(true);
+        ProviderEnvironment env = (ProviderEnvironment) providerEnvironment.get(context);
+
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9897")));
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9896")));
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9899")));
+        Assert.assertEquals(3, env.getBlackList().size());
+    }
+
+    @Test
+    public void testComesBackUp() throws Exception {
+        FastHashtable<String, Object> props = new FastHashtable<>();
+
+        // Include all servers, so that retries are also tested
+        props.put("java.naming.provider.url", "remote://localhost:9897,remote://localhost:9896");
+        props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
+        WildFlyRootContext context = new WildFlyRootContext(props);
+
+        ExhaustedDestinationsException t = null;
+        try {
+            for (int i = 0; i < 10; i++) {
+                context.bind("hello", "there");
+            }
+        } catch (ExhaustedDestinationsException o) {
+            t = o;
+        }
+        Assert.assertNotNull(t);
+
+        Field providerEnvironment = context.getClass().getDeclaredField("providerEnvironment");
+        providerEnvironment.setAccessible(true);
+        ProviderEnvironment env = (ProviderEnvironment) providerEnvironment.get(context);
+
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9897")));
+        Assert.assertTrue(env.getBlackList().containsKey(new URI("remote://localhost:9896")));
+        Assert.assertEquals(2, env.getBlackList().size());
+
+        t = null;
+        try {
+            context.bind("hello", "there");
+        } catch (ExhaustedDestinationsException o) {
+            t = o;
+        }
+
+        Assert.assertNotNull(t);
+
+        // This case the black list should have prevented the attempt
+        Assert.assertTrue(t.getSuppressed() == null || t.getSuppressed().length == 0);
+
+        // Force expire
+        env.getBlackList().replace(new URI("remote://localhost:9896"), System.currentTimeMillis());
+        TestServer server = new TestServer("test2", "localhost", 9896);
+        server.start();
+
+        // Should work  now
+        Object result = null;
+        try {
+            context.bind("hello", "there");
+            result = context.lookup("hello");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            server.stop();
+        }
+
+        // Black-list should be gone now
+        Assert.assertEquals("there", result);
+        Assert.assertFalse(env.getBlackList().containsKey(new URI("remote://localhost:9896")));
+    }
 
     @Test
     public void testJavaSchemeWithJavaName() throws NamingException {
@@ -52,6 +308,5 @@ public class RemoteContextTestCase {
     private Name createName(String name) throws NamingException {
         final WildFlyRootContext context = new WildFlyRootContext(new FastHashtable<>());
         return context.getNameParser(name).parse(name);
-
     }
 }

--- a/src/test/java/org/wildfly/naming/client/remote/TestServer.java
+++ b/src/test/java/org/wildfly/naming/client/remote/TestServer.java
@@ -1,0 +1,103 @@
+package org.wildfly.naming.client.remote;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.EndpointBuilder;
+import org.jboss.remoting3.spi.NetworkServerProvider;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.permission.PermissionVerifier;
+import org.wildfly.security.sasl.util.SaslFactories;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Sequence;
+import org.xnio.StreamConnection;
+import org.xnio.Xnio;
+import org.xnio.channels.AcceptingChannel;
+
+/**
+ * @author Jason T. Greene
+ */
+public class TestServer {
+
+    private String endpointName;
+    private Endpoint endpoint;
+    private String host;
+    private int port;
+    private AcceptingChannel<StreamConnection> server;
+
+    TestServer(String endpointName, String host, int port) {
+        this.endpointName = endpointName;
+        this.host = host;
+        this.port = port;
+    }
+
+    public void start() throws Exception {
+        // create a Remoting endpoint
+        final OptionMap options = OptionMap.EMPTY;
+        EndpointBuilder endpointBuilder = Endpoint.builder();
+        endpointBuilder.setEndpointName(this.endpointName);
+        endpointBuilder.buildXnioWorker(Xnio.getInstance()).populateFromOptions(options).build();
+        this.endpoint = endpointBuilder.build();
+
+
+        RemoteNamingService service = new RemoteNamingService(new FlatMockContext());
+        service.start(endpoint);
+
+        // set up a security realm called default with a user called test
+        final SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+        realm.setPasswordMap("test", ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, "test".toCharArray()));
+
+        // set up a security domain which has realm "default"
+        final SecurityDomain.Builder domainBuilder = SecurityDomain.builder();
+        domainBuilder.addRealm("default", realm).build();                                  // add the security realm called "default" to the security domain
+        domainBuilder.setDefaultRealmName("default");
+        domainBuilder.setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.ALL);
+        SecurityDomain testDomain = domainBuilder.build();
+
+
+        // set up a SaslAuthenticationFactory (i.e. a SaslServerFactory)
+        SaslAuthenticationFactory saslAuthenticationFactory = SaslAuthenticationFactory.builder()
+                .setSecurityDomain(testDomain)
+                .setMechanismConfigurationSelector(mechanismInformation -> {
+                    switch (mechanismInformation.getMechanismName()) {
+                        case "ANONYMOUS":
+                        case "PLAIN": {
+                            return MechanismConfiguration.EMPTY;
+                        }
+                        default: return null;
+                    }
+                })
+                .setFactory(SaslFactories.getElytronSaslServerFactory())
+                .build();
+        final OptionMap serverOptions = OptionMap.create(Options.SASL_MECHANISMS, Sequence.of("ANONYMOUS"), Options.SASL_POLICY_NOANONYMOUS, Boolean.FALSE);
+        final NetworkServerProvider serverProvider = endpoint.getConnectionProviderInterface("remote", NetworkServerProvider.class);
+        final SocketAddress bindAddress = new InetSocketAddress(InetAddress.getByName(host), port);
+        this.server = serverProvider.createServer(bindAddress, serverOptions, saslAuthenticationFactory, null);
+
+
+    }
+
+    public void stop() {
+        try {
+            server.close();
+        } catch (Throwable t)
+        {
+            // Yum
+        }
+
+        try {
+            endpoint.close();
+        } catch (Throwable t)
+        {
+            // Yum
+        }
+    }
+
+}


### PR DESCRIPTION
Change Overview
---------------

This commit accomplishes the following:

1. Introduces a new RetryContext which acts as an invocation context, storing
   information that persists across multiple interactions with a peer, each
   attempting to accomplish a single invocation, the naming operation.

2. Replaces the generic BiFunction with a typed NamingOperation. The typed
   NamingOperation acts as a tri-argument form, utilizing the RetryContext,
   the primary Name the operation is operating against, and an optional
   parameter.

3. Introduces two variations of black-listing behavior, which are used in
   concert to mitigate failure conditions when retrying:

   - A time-based black-list, which utilizes base 2 exponential growth to
     implement a back-off multiplier. The back-off time starts at roughly a
     minute, and doubles each failure until it remains fixed at 6 days. Due
     to the time-based nature, this spans multiple invocations.

   - A transient failure list, which prevents a URI from being retried
     more than once in a single invocation.

   The time-based black-list is utilized for communication failures, whereas
   transient failures are used for NameNotFound exceptions and all unknown
   throwables thrown during an operation. The former allows for heterogeneous
   topologies, where different names are present on different hosts. In this
   case, the naming client will retry (currently up to eight times) until it
   finds a host which does not return NameNotFound. Unknown throwables also
   utilize the transient failure approach, as they may not indicate an actual
   problem with the server, but rather a client bug. All subclasses other
   than NameNotFound are treated as a valid complete response, with no need to
   contact other hosts.

4. Add methods to ProviderEnvironment to support usage of the time-based
   black-list. By attaching the black-list to ProviderEnvironemnt, the scope
   from a user's perspective becomes an InitialContext. Multiple invocations
   on an InitialContext reuse the black-list, whereas invocations that span
   InitialContexts do not, as each context has its own isolated scope.

   The black-list is represented as a ConcurrentHashMap with a URI key and an
   encoded long for storing the expiration time and backoff state. The format
   of the long value is encoded as follows:
```
          6         5         4         3         2         1
      4 2 0 8 6 4 2 0 8 6 4 2 0 8 6 4 2 0 8 6 4 2 0 8 6 4 2 0 8 6 4 2 0
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      |      Expiration Time (millis since epoch)      |   Back-off   |
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

      Expiration Time:  Most significant 49 bits of 64 bit timestamp
                        indicating expiration from the black-list.

      Back-off:         Represents base 2 power for delay multiplier.
                        Range 2^1 - 2^14 (bit 0 is reserved)
```
   This layout is specifically chosen for the following properties:

   + Avoid precision loss at the upper bound of the timestamp.

   + Minimizes precision loss on the lower bound to 65,535 millis, which is
     a desirable minimum back-off (~ 1 minute)

     - Adding one to bit 15 as part of adding the back-off to the timestamp
       can help minimize the lower precision loss, thereby adjusting the time
       to be a ceiling.

   + Allows efficient calculation of the next delay interval and expiration
     time, by simply bit-shifting the back-off and adding it to the expiration
     time section. (effectively adding a computed multiple of 65,535)

   + Can still lead to reasonable results even when the client treats the whole
     64 bit value as timestamp.

   The following example shows the expected back-off growth (Note some variance
   is expected, since the input is a live timestamp, with a ceiling computation):

                        1 mins, 37 secs, 607 mils   2¹ + 1 -> (2¹⁶ + 2¹⁵)
                        2 mins, 43 secs, 142 mils   2² + 1 -> (2¹⁷ + 2¹⁵)
                        4 mins, 54 secs, 213 mils   2³ + 1 -> (2¹⁸ + 2¹⁵)
                        9 mins, 16 secs, 357 mils   2⁴ + 1 -> (2¹⁹ + 2¹⁵)
                       18 mins, 00 secs, 644 mils   2⁵ + 1 -> (2²⁰ + 2¹⁵)
                       35 mins, 29 secs, 220 mils   2⁶ + 1 -> (2²¹ + 2¹⁵)
              1 hours, 10 mins, 26 secs, 371 mils   2⁷ + 1 -> (2²² + 2¹⁵)
              2 hours, 20 mins, 20 secs, 675 mils   2⁸ + 1 -> (2²³ + 2¹⁵)
              4 hours, 40 mins, 09 secs, 282 mils   2⁹ + 1 -> (2²⁴ + 2¹⁵)
              9 hours, 19 mins, 46 secs, 498 mils  2¹⁰ + 1 -> (2²⁵ + 2¹⁵)
             18 hours, 39 mins, 00 secs, 929 mils  2¹¹ + 1 -> (2²⁶ + 2¹⁵)
     1 days, 13 hours, 17 mins, 29 secs, 793 mils  2¹² + 1 -> (2²⁷ + 2¹⁵)
     3 days, 02 hours, 34 mins, 27 secs, 520 mils  2¹³ + 1 -> (2²⁸ + 2¹⁵)
     6 days, 05 hours, 08 mins, 22 secs, 976 mils  2¹⁴ + 1 -> (2²⁹ + 2¹⁵)

5. Adds additional default methods to NamingProvider, which accept a
   RetryContext as a parameter. Specifying a RetryContext indicates that the
   provider should retry the operation as described above. A null context
   value indicates that an operation should not be retried. The default
   methods implement destination election and usage of the black-list and
   transient failure list.

6. Modifies RemoteContext to utilize the above to implement retry behavior.

7. Introduces exception aggregation. All errors encountered while retrying a
   naming operation are truncated and appended to new ExhastedDestinations
   exception,  which extends CommunicationExcaption. On the other hand,
   NameNotFoundException, since it represents a valid expected result will
   supersede all other exceptions encountered during a retry. This is
   primarily to maintain expectations from calling client code. As mentioned
   above, all other NamingException subclasses are legitimate results that do
   not require retrying, so they are directly rethrown when encountered.

8. Adds a new mock remote naming test server, and a number of tests that
   verify the behavior described above.

Memory Impact
-------------

This change aims to limit the additional memory required to support this
enhancement. Single destination configurations should be largely unaffected by
this change since RetryContext is only allocated when multiple URIs are
configured.

This multi-destination case does require additional state management. However
care was taken to limit the impact (e.g. collection types initialize to the
shared empty instance, and are lazily converted when necessary)). Most of the
additional allocations occur only under failure conditions.