### PR TITLE
[WFNC-50] - [GSS](7.1.0) use of WildFlyInitialContext with wildfly-co…

### DIFF
--- a/src/main/java/org/wildfly/naming/client/WildFlyInitialContext.java
+++ b/src/main/java/org/wildfly/naming/client/WildFlyInitialContext.java
@@ -62,7 +62,7 @@ public final class WildFlyInitialContext extends InitialLdapContext {
     }
 
     protected Context getDefaultInitCtx() throws NamingException {
-        throw new NoInitialContextException();
+        return rootContext;
     }
     
     public FastHashtable<String, Object> getEnvironment() throws NamingException {


### PR DESCRIPTION
…nfig.xml throws javax.naming.NoInitialContextException

Issue: https://issues.jboss.org/browse/WFNC-50