### PR TITLE
WFNC-91 Use github workflow cache action to speed up ci run; and incr…

### DIFF
--- a/.github/workflows/ci-manual.yml
+++ b/.github/workflows/ci-manual.yml
@@ -50,6 +50,7 @@ jobs:
       with:
         distribution: ${{ inputs.jdk-distribution }}
         java-version: ${{ inputs.jdk-version }}
+        cache: 'maven'
     - name: Run Tests
       run: mvn -ntp -U -B -fae clean verify
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-test-matrix:
     name: ${{ matrix.jdk-distribution }}-${{ matrix.jdk-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +36,7 @@ jobs:
       with:
         distribution: ${{ matrix.jdk-distribution }}
         java-version: ${{ matrix.jdk-version }}
+        cache: 'maven'
     - name: Run Tests
       run: mvn -ntp -U -B -fae clean install
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
…ease ci timeout

https://issues.redhat.com/browse/WFNC-91