### PR TITLE
Revert "Bump org.jboss.threads:jboss-threads from 3.7.0.Final to 3.8.0.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <version.org.jboss.logging.jboss-logging-processor>3.0.2.Final</version.org.jboss.logging.jboss-logging-processor>
         <version.org.jboss.marshalling>2.2.1.Final</version.org.jboss.marshalling>
         <version.org.jboss.remoting>5.0.29.Final</version.org.jboss.remoting>
-        <version.org.jboss.threads>3.8.0.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>3.7.0.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.8.16.Final</version.org.jboss.xnio>
         <version.org.kohsuke.metainf-services>1.11</version.org.kohsuke.metainf-services>
         <version.org.wildfly.client>1.0.1.Final</version.org.wildfly.client>


### PR DESCRIPTION
To bring back CI to normal

This reverts commit 63bc88da6a9624e7f8af6c4385353cf39c3a1c63.